### PR TITLE
Setup db adapter in config

### DIFF
--- a/conf/config
+++ b/conf/config
@@ -20,15 +20,6 @@ PORT = 5000 # server port
 
 DEBUG = on # off # open debug mode
 
-
-## Flask Session module
-# session
-SECRET_KEY = "7oGwHH8NQDKn9hL12Gak9G/MEjZZYk4PsAxqKU4cJoY="
-SESSION_TYPE = "filesystem"
-SESSION_FILE_DIR = "/var/www/$yoursite.com/cookies"
-
-
-
 ## Flask Session module
 # session
 SECRET_KEY = "7oGwHH8NQDKn9hL12Gak9G/MEjZZYk4PsAxqKU4cJoY="
@@ -41,10 +32,6 @@ SESSION_FILE_DIR = "cookie"
 SESSION_FILE_THRESHOLD = 100
 SESSION_FILE_MODE = 0600
 
-SESSION_FILE_THRESHOLD = 100
-SESSION_FILE_MODE = 0600
-
-
 ## DB Config
 DB_CONFIG  {
     db = white
@@ -54,6 +41,9 @@ DB_CONFIG  {
 
     max_idle = 10 # the mysql timeout setting
 }
+
+# DB Adapter
+DB_ADAPTER = mysql # or pymysql
 
 # DB POOL Size 
 DB_MAXCONN = 10

--- a/white/server.py
+++ b/white/server.py
@@ -124,9 +124,10 @@ class WhiteServer(object):
         from white import orm
 
         config = self.app.config.get('DB_CONFIG')
+        adapter = self.app.config.get('DB_ADAPTER', 'mysql')
         minconn = self.app.config.get('MINCONN', 5)
         maxconn = self.app.config.get('MAXCONN', 10)
-        db.setup(config, minconn=minconn, maxconn=maxconn)
+        db.setup(config, minconn=minconn, maxconn=maxconn, adapter=adapter)
 
         orm.setup()
 


### PR DESCRIPTION
Remove some duplicate settings and add `DB_ADAPTER` setting support.
Because update and rerun this project, received a error `NotInstallDriverError("Must install MySQLdb module fistly")`. After read the `dbpy` API, i tried the `pymysql` adapter.
Actually, it worked after reinstall `MySQL-python` module too. 🤣 